### PR TITLE
replaced the API call to the registry, with the couchDB-API

### DIFF
--- a/lib/ember-addons.js
+++ b/lib/ember-addons.js
@@ -6,7 +6,7 @@ const find = require('lodash/find');
 const { cleanAddons, hasName } = require('./cleanAddons');
 
 const Registry = require('npm-registry');
-const npm = new Registry({ registry: 'http://registry.npmjs.org/' });
+const npm = new Registry({ registry: 'https://registry.npmjs.org/' });
 
 const EMBER_OBSERVER_API_URL = 'https://www.emberobserver.com/api/v2/autocomplete_data';
 const EMBER_ADDON_KEYWORD = 'ember-addon';
@@ -15,6 +15,10 @@ const IGNORE_ADDON_PATTERNS = [
   /fill-murry/,
   /test-addonasdasdcxvsdfsfsbsdfscxvcvxdvsdfsdfsdfxcvxcvs12431123mvhxcvxcvx/
 ];
+const NPM_COUCH_DB_URL = `https://skimdb.npmjs.com/registry/_design/app/_view/byKeyword
+  ?startkey=["ember-addon"]
+  &endkey=["ember-addon",{}]
+  &group_level=3`;
 
 function ignoredAddons(addon) {
   // Returns true if addon.name does not match
@@ -32,16 +36,28 @@ function ignoredAddons(addon) {
 
 function getAll() {
   return new Promise(function(resolve, reject) {
-    npm.packages.keyword(EMBER_ADDON_KEYWORD, function(err, results) {
+    // Hit the couchDB of NPM. The common registry endpoint is limited to 250 entries per search.
+    // Its the only place to get all addon names with the keyWord 'ember-addon'.
+    return request({ url: NPM_COUCH_DB_URL json: true }, (err, response, body)=> {
       if (err) {
         return reject(err);
       }
+      // We only need the names of the addons and receive the details later.
+      // The NPM couchDB doesn't give much more details anyways
+      const addons = body.rows.reduce((filteredAddons, row)=> {
+        const name        = row.key[1];
+        const ignoreAddon = IGNORE_ADDON_PATTERNS.every((pattern)=> !pattern.test(name));
 
-      const filtered = results.filter(ignoredAddons);
-      console.log('--> Found addon count:', results.length);
-      console.log('--> Filtered addon count:', filtered.length);
-      resolve(filtered);
-    });
+        if (hasName({ name }) && ignoreAddon) {
+          filteredAddons.push({name: name})
+        };
+
+        return filteredAddons;
+      }, []);
+
+      resolve(addons);
+      }
+    );
   });
 }
 
@@ -58,8 +74,8 @@ function _getDetails(name) {
 }
 
 function getDetailsForAddons(addons) {
-  const fitered = addons.filter(hasName);
-  return Promise.map(fitered, (addon) => {
+  const filtered = addons.filter(hasName);
+  return Promise.map(filtered, (addon) => {
     console.log('--> Fetching addon info:', addon.name);
     return _getDetails(addon.name).then((r) => r[0]);
   }, { concurrency: 10 });

--- a/lib/ember-addons.js
+++ b/lib/ember-addons.js
@@ -38,7 +38,7 @@ function getAll() {
   return new Promise(function(resolve, reject) {
     // Hit the couchDB of NPM. The common registry endpoint is limited to 250 entries per search.
     // Its the only place to get all addon names with the keyWord 'ember-addon'.
-    return request({ url: NPM_COUCH_DB_URL json: true }, (err, response, body)=> {
+    return request({ url: NPM_COUCH_DB_URL, json: true }, (err, response, body)=> {
       if (err) {
         return reject(err);
       }

--- a/lib/ember-addons.js
+++ b/lib/ember-addons.js
@@ -15,10 +15,7 @@ const IGNORE_ADDON_PATTERNS = [
   /fill-murry/,
   /test-addonasdasdcxvsdfsfsbsdfscxvcvxdvsdfsdfsdfxcvxcvs12431123mvhxcvxcvx/
 ];
-const NPM_COUCH_DB_URL = `https://skimdb.npmjs.com/registry/_design/app/_view/byKeyword
-  ?startkey=["ember-addon"]
-  &endkey=["ember-addon",{}]
-  &group_level=3`;
+const NPM_COUCH_DB_URL = 'https://skimdb.npmjs.com/registry/_design/app/_view/byKeyword?startkey=["ember-addon"]&endkey=["ember-addon",{}]&group_level=3';
 
 function ignoredAddons(addon) {
   // Returns true if addon.name does not match
@@ -44,6 +41,7 @@ function getAll() {
       }
       // We only need the names of the addons and receive the details later.
       // The NPM couchDB doesn't give much more details anyways
+      console.log(body);
       const addons = body.rows.reduce((filteredAddons, row)=> {
         const name        = row.key[1];
         const ignoreAddon = IGNORE_ADDON_PATTERNS.every((pattern)=> !pattern.test(name));


### PR DESCRIPTION
**Problem:** 
The list of ember-addons doesn't get updated.
NPM removed the API endpoint, which "npm-registry" uses to load all names of the npm packages with the keyword "ember-addon". 

**Solution**
There is still the API for the couchDB of NPM at https://skimdb.npmjs.com/registry

I will add some code comments. I hope this PR is alright in that style.
Oh and of course I couldnt test the data-uploading, etc. I just wrote the output to a JSON file locally to check the output.